### PR TITLE
Send the evaluation of the injectedJavaScript prop back to the React Native side

### DIFF
--- a/React/Views/RCTWebView.m
+++ b/React/Views/RCTWebView.m
@@ -184,11 +184,13 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
 - (void)webViewDidFinishLoad:(UIWebView *)webView
 {
   if (_injectedJavaScript != nil) {
-    [webView stringByEvaluatingJavaScriptFromString:_injectedJavaScript];
+    NSString *jsEvaluationValue = [webView stringByEvaluatingJavaScriptFromString:_injectedJavaScript];
+    NSMutableDictionary *event = [self baseEvent];
+    [event addEntriesFromDictionary: @{@"jsEvaluationValue":jsEvaluationValue}];
+    _onLoadingFinish(event);
   }
-
   // we only need the final 'finishLoad' call so only fire the event when we're actually done loading.
-  if (_onLoadingFinish && !webView.loading && ![webView.request.URL.absoluteString isEqualToString:@"about:blank"]) {
+  else if (_onLoadingFinish && !webView.loading && ![webView.request.URL.absoluteString isEqualToString:@"about:blank"]) {
     _onLoadingFinish([self baseEvent]);
   }
 }


### PR DESCRIPTION
We have a use case in the development of our app, where we are rendering some HTML content in a web view. But this content comes from the back end, and varies in height. There are other components on the page, so it's not a full screen web view. We need to dynamically alter the web view height, to fit the HTML content without scrolling, and to push the non-web view content on the screen down.

The solution I came up with, was to use the _loadingFinish callback, to send the evaluation of the injectedJavaScript property back to the React Native side.
